### PR TITLE
Add beforeSaveMessage Closure. Add testEventSaveMessageCallback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,15 @@ class News extends ActiveRecord
                 'getEntityId' => function () {
                     return $this->global_news_id;
                 }
-
+                /** 
+                 * В случаях когда нужно для конкретного ActiveLogBehavior делать подпись с понятным названием.
+                 * Если на странице выводятся история изменения всех пользователей,  
+                 * то невсегда понятно у кого именно изменился статут, день рождения или другие данные
+                 */
+                'beforeSaveMessage' => function ($data) {
+                    return ['attribute' => 'custom data'] + $data;
+                }
+                
                 // Список полей за изменением которых будет производиться слежение
                 'attributes' => [
                     // Простые поля ( string|int|bool )

--- a/src/ActiveLogBehavior.php
+++ b/src/ActiveLogBehavior.php
@@ -73,6 +73,11 @@ class ActiveLogBehavior extends Behavior
      * @var bool
      */
     public $softDelete = false;
+
+    /**
+     * @var null|\Closure
+     */
+    public $beforeSaveMessage;
     /**
      * @var array
      *  - create
@@ -379,6 +384,9 @@ class ActiveLogBehavior extends Behavior
     {
         $name = self::EVENT_BEFORE_SAVE_MESSAGE;
 
+        if ($this->beforeSaveMessage !== null) {
+            return call_user_func($this->beforeSaveMessage, $data);
+        }
         if (method_exists($this->owner, $name)) {
             return $this->owner->$name($data);
         }

--- a/test/models/User.php
+++ b/test/models/User.php
@@ -66,7 +66,7 @@ class User extends ActiveRecord
 
             [['salary'], 'number'],
 
-            [['birthday'], 'date'],
+            [['birthday'], 'date', 'format' => 'dd.MM.yyyy'],
 
             [['status'], 'default', 'value' => self::STATUS_ACTIVE],
             [['status'], 'integer'],


### PR DESCRIPTION
Подкидывает custom запись в лог, когда необходимо сделать подпись в логах, в тех случаях, когда не совсем понятно, у какой сущности производились изменения.