### PR TITLE
Console fix

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -176,13 +176,12 @@ class Manager extends BaseObject
      */
     public function clean(array $options = [])
     {
-        $options = array_merge(['deleteOldThanDays' => $this->deleteOldThanDays * 86400], $options);
-
-        if ($options['deleteOldThanDays'] === 0) {
-            return false;
+        if (isset($options['deleteOldThanDays'])) {
+            $options['createdAt'] = $options['deleteOldThanDays'];
+            unset($options['deleteOldThanDays']);
+        } elseif ($this->deleteOldThanDays !== false) {
+            $options['createdAt'] = time() - $this->deleteOldThanDays * 86400;
         }
-
-        $options['createdAt'] = time() - $options['deleteOldThanDays'];
 
         return $this->deleteMessage($options);
     }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -176,6 +176,10 @@ class Manager extends BaseObject
      */
     public function clean(array $options = [])
     {
+        if (empty($options)) {
+            return false;
+        }
+
         if (isset($options['deleteOldThanDays'])) {
             $options['createdAt'] = $options['deleteOldThanDays'];
             unset($options['deleteOldThanDays']);


### PR DESCRIPTION
Добавил возможность использовать clean без периода (deleteOldThanDays), то есть удалить все entity_name без временной метки, а так же исправил ошибку Exception 'yii\base\UnknownPropertyException' with message 'Setting unknown property: lav45\activityLogger\LogMessage::deleteOldThanDays' при передаче значения в --old-than
Если не передать ни одного параметра, удаления не будет, чтобы не вытереть случайно все логи...